### PR TITLE
feat: add hyperparameter tuning for RandomForest classifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 __pycache__/
 models/saved/
 .env
+CONTEXT_DUMP.md
+EXTRACT_LANDMARKS_GUIDE.txt

--- a/config.py
+++ b/config.py
@@ -1,3 +1,8 @@
+import os
+
+# ── Base Directory ────────────────────────────────────
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
 # ── Camera ────────────────────────────────────────────
 CAMERA_INDEX = 0              # Default webcam index
 CAM_WIDTH = 1280              # Capture width
@@ -8,7 +13,7 @@ MAX_HANDS = 2                 # Max simultaneous hands
 DETECTION_CONFIDENCE = 0.7    # Min detection confidence
 TRACKING_CONFIDENCE = 0.7     # Min tracking confidence
 
-# ── Mouse Controller ─────────────────────────────────
+# ── Mouse Controller ──────────────────────────────────
 SMOOTHING_ALPHA = 0.3         # Exponential smoothing (0.2–0.35)
 FRAME_REDUCTION = 150         # Edge padding for coordinate mapping
 
@@ -30,7 +35,7 @@ IMAGES_PER_CLASS = 50
 COUNTDOWN = 3
 DELAY_BETWEEN_CLASSES = 50 # milliseconds
 
-# ── Model ───────────────────────────────────────────
+# ── Model ─────────────────────────────────────────────
 NUM_CLASSES = len(CLASSES)
 DATA_DIR= "./data/raw"
 
@@ -40,7 +45,7 @@ DATA_DIR= "./data/raw"
 # ── ASL MNIST ─────────────────────────────────────────
 ASL_MNIST_DIR = "data/asl_mnist"
 
-# augmentation settings
+# ── Augmentation Settings ─────────────────────────────
 AUGMENT_CONFIG = {
     "flip": True,
     "rotate": True,
@@ -48,3 +53,10 @@ AUGMENT_CONFIG = {
     "zoom": False,
     "factor": 5
 }
+
+# ── Hyperparameter Tuning ─────────────────────────────
+RF_PARAM_GRID = {
+    "n_estimators": [50, 100, 200],
+    "max_depth": [None, 10, 20, 30],
+}
+CV_FOLDS = 5

--- a/models/train_model.py
+++ b/models/train_model.py
@@ -1,26 +1,13 @@
 # training script
 import pickle
 import os
-import numpy as np
-from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score
+from utils.data_loader import load_landmark_data
+from config import BASE_DIR
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-data_path = os.path.join(BASE_DIR, "data", "landmarks.pickle")
+X_train, X_test, y_train, y_test = load_landmark_data()
 
-if not os.path.exists(data_path):
-    print("Error: Run python data/extract_landmarks.py first.")
-    exit(1)
-
-with open(data_path, "rb") as f:
-    dataset = pickle.load(f)
-
-X = np.array(dataset["data"])
-y = np.array(dataset["labels"])
-
-# stratify ensures equal class distribution in both train and test sets
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42, stratify=y)
 model = RandomForestClassifier(n_estimators=100, random_state=42).fit(X_train, y_train)
 y_pred = model.predict(X_test)
 accuracy = accuracy_score(y_test, y_pred)

--- a/models/tune_model.py
+++ b/models/tune_model.py
@@ -1,0 +1,54 @@
+import pickle
+import os
+from sklearn.model_selection import GridSearchCV
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+from utils.data_loader import load_landmark_data
+from config import BASE_DIR, RF_PARAM_GRID, CV_FOLDS
+
+X_train, X_test, y_train, y_test = load_landmark_data()
+
+rf = RandomForestClassifier(random_state=42)
+grid_search = GridSearchCV(
+    estimator=rf,
+    param_grid=RF_PARAM_GRID,
+    cv=CV_FOLDS,
+    scoring="accuracy",
+    verbose=2,
+    n_jobs=-1,
+    return_train_score=True,
+)
+
+grid_search.fit(X_train, y_train)
+
+# Print best parameters and accuracy
+print(f"\n{'='*60}")
+print(f"Best Parameters: {grid_search.best_params_}")
+print(f"Best CV Accuracy: {grid_search.best_score_:.4f}")
+print(f"{'='*60}\n")
+
+# Print comparison table of all combinations
+results = grid_search.cv_results_
+print(f"{'Rank':<6} {'n_estimators':<15} {'max_depth':<12} {'Mean CV Acc':<15} {'Std':<10}")
+print("-" * 58)
+
+for i in range(len(results["params"])):
+    rank = results["rank_test_score"][i]
+    params = results["params"][i]
+    mean_score = results["mean_test_score"][i]
+    std_score = results["std_test_score"][i]
+    print(f"{rank:<6} {params['n_estimators']:<15} {str(params['max_depth']):<12} {mean_score:<15.4f} {std_score:<10.4f}")
+
+best_model = grid_search.best_estimator_
+y_pred = best_model.predict(X_test)
+test_accuracy = accuracy_score(y_test, y_pred)
+print(f"\nTest Set Accuracy (best model): {test_accuracy:.4f}")
+
+model_dir = os.path.join(BASE_DIR, "models", "saved")
+os.makedirs(model_dir, exist_ok=True)
+model_path = os.path.join(model_dir, "model_rf_tuned.p")
+
+with open(model_path, "wb") as f:
+    pickle.dump(best_model, f)
+
+print(f"Best tuned model saved to {model_path}")

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -1,0 +1,25 @@
+import pickle
+import os
+import numpy as np
+from sklearn.model_selection import train_test_split
+from config import BASE_DIR
+
+def load_landmark_data(test_size=0.2, random_state=42):
+    # Loads landmark data and returns train/test splits.
+    data_path = os.path.join(BASE_DIR, "data", "landmarks.pickle")
+
+    if not os.path.exists(data_path):
+        print("Error: Run python data/extract_landmarks.py first.")
+        exit(1)
+
+    with open(data_path, "rb") as f:
+        dataset = pickle.load(f)
+
+    X = np.array(dataset["data"])
+    y = np.array(dataset["labels"])
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y
+    )
+
+    return X_train, X_test, y_train, y_test


### PR DESCRIPTION
- Add models/tune_model.py: performs grid search over n_estimators [50, 100, 200] and max_depth [None, 10, 20, 30] using GridSearchCV with 5-fold cross-validation. Prints best parameters, CV accuracy, a ranked comparison table, and saves the best model to models/saved/model_rf_tuned.p.

- Add utils/data_loader.py: extract shared data loading and train/test splitting logic into a reusable load_landmark_data() function to eliminate duplication between train_model.py and tune_model.py.

- Refactor models/train_model.py: use shared load_landmark_data() utility and import BASE_DIR from config.

- Update config.py: centralize BASE_DIR, add RF_PARAM_GRID and CV_FOLDS constants, clean up section comment formatting.