### PR TITLE
feat: add prediction smoothing to stabilize sign display (issue-16)

### DIFF
--- a/config.py
+++ b/config.py
@@ -60,3 +60,7 @@ RF_PARAM_GRID = {
     "max_depth": [None, 10, 20, 30],
 }
 CV_FOLDS = 5
+
+# ── Prediction Smoothing ─────────────────────────────
+SMOOTHING_WINDOW_SIZE = 15       # Number of recent predictions to keep
+SMOOTHING_DOMINANCE_THRESHOLD = 0.6  # 60% dominance required to update display

--- a/main.py
+++ b/main.py
@@ -1,15 +1,16 @@
-from xml.parsers.expat import model
-
 import cv2
 import time
+import pickle
 from core.hand_detector import HandDetector
 from core.feature_extractor import FeatureExtractor
+from utils.prediction_smoother import PredictionSmoother
 from controllers.mouse_controller import MouseController
 from controllers.sign_language_controller import SignLanguageController
 from config import (
     CAMERA_INDEX, CAM_WIDTH, CAM_HEIGHT,
     MAX_HANDS, DETECTION_CONFIDENCE, TRACKING_CONFIDENCE,
     SMOOTHING_ALPHA, WINDOW_TITLE,
+    SMOOTHING_WINDOW_SIZE, SMOOTHING_DOMINANCE_THRESHOLD
 )
 
 # Initialize controllers
@@ -26,18 +27,20 @@ current_max_hands = MAX_HANDS
 
 fe=FeatureExtractor(use_z=False)
 
-import pickle 
+# Load trained model
 try:
     with open(".modelss/trained_model.pkl", "rb") as f:
         model = pickle.load(f)
 except FileNotFoundError:
     print("Trained model not found. Please run 'train_model.py' first to create the model file.")
     model=None
+
 # Initialize webcam
 cap = cv2.VideoCapture(CAMERA_INDEX)
 cap.set(cv2.CAP_PROP_FRAME_WIDTH, CAM_WIDTH)
 cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAM_HEIGHT)
 
+# Check if camera opened successfully
 if not cap.isOpened():
     print("Failed to open camera")
     exit()
@@ -45,8 +48,14 @@ if not cap.isOpened():
 # Runtime state
 prev_time = 0
 mode = "mouse"
+
 # hand detection mode toggle
 max_hands_mode = 1 #start with single hand mode
+
+# Initialize prediction smoother
+smoother = PredictionSmoother(window_size=SMOOTHING_WINDOW_SIZE, dominance_threshold=SMOOTHING_DOMINANCE_THRESHOLD)
+displayed_sign = None
+
 # Main loop
 while True:
     success, frame = cap.read()
@@ -66,6 +75,16 @@ while True:
         # Test FeatureExtractor
         features = fe.extract(landmarks)
         normalized = fe.normalize(features)
+
+        # Predict sign 
+        if model is not None:
+            prediction = model.predict(normalized.reshape(1, -1))[0]
+            smoother.add_prediction(prediction)
+            stable_prediction = smoother.get_stable_prediction()
+
+            # Update displayed sign if stable prediction is available
+            if stable_prediction is not None:
+                displayed_sign = stable_prediction
         
         # Print debug info
         print(f"Features shape: {features.shape}")
@@ -88,6 +107,11 @@ while True:
     cv2.putText(frame, f'Hands: {max_hands_mode}', (10, 60), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
     cv2.putText(frame, f'Mode: {mode}', (10, 90), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
 
+    # Display sign if available
+    if displayed_sign:
+        cv2.putText(frame, f'Sign: {displayed_sign}', (10, 120),
+                    cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+
     cv2.imshow(WINDOW_TITLE, frame)
 
     # Handle keypresses
@@ -98,6 +122,7 @@ while True:
         break"""
     
     key = cv2.waitKey(1) & 0xFF
+    
     if key == ord('m'):
         mode = "sign_language" if mode == "mouse" else "mouse"
     if key == ord('h'):
@@ -107,5 +132,6 @@ while True:
         print(f'Hand dectection mode: {max_hands_mode} hand(s)')
     if key == 27 or cv2.getWindowProperty(WINDOW_TITLE, cv2.WND_PROP_VISIBLE) < 1:
         break
+
 cap.release()
 cv2.destroyAllWindows()

--- a/tests/test_prediction_smoother.py
+++ b/tests/test_prediction_smoother.py
@@ -1,0 +1,72 @@
+import pytest
+from utils.prediction_smoother import PredictionSmoother
+
+
+def test_empty_history():
+    """get_stable_prediction should return None when no predictions have been added."""
+    smoother = PredictionSmoother(window_size=5, dominance_threshold=0.6)
+    assert smoother.get_stable_prediction() is None
+
+
+def test_clear_dominance():
+    """Should return the dominant prediction when one sign fills the entire window."""
+    smoother = PredictionSmoother(window_size=5, dominance_threshold=0.6)
+    for _ in range(5):
+        smoother.add_prediction("A")
+    assert smoother.get_stable_prediction() == "A"
+
+
+def test_no_dominance():
+    """Should return None when no single prediction exceeds the threshold."""
+    smoother = PredictionSmoother(window_size=6, dominance_threshold=0.6)
+    for sign in ["A", "B", "C", "A", "B", "C"]:
+        smoother.add_prediction(sign)
+    assert smoother.get_stable_prediction() is None
+
+
+def test_threshold_boundary_met():
+    """Should return the dominant sign when it hits exactly 60%."""
+    smoother = PredictionSmoother(window_size=5, dominance_threshold=0.6)
+    for sign in ["A", "A", "A", "B", "B"]:  # A = 60%
+        smoother.add_prediction(sign)
+    assert smoother.get_stable_prediction() == "A"
+
+
+def test_threshold_boundary_not_met():
+    """Should return None when the top sign is just below the threshold."""
+    smoother = PredictionSmoother(window_size=5, dominance_threshold=0.6)
+    for sign in ["A", "A", "B", "B", "C"]:  # A = 40%
+        smoother.add_prediction(sign)
+    assert smoother.get_stable_prediction() is None
+
+
+def test_sliding_window():
+    """Old predictions should slide out of the window as new ones are added."""
+    smoother = PredictionSmoother(window_size=5, dominance_threshold=0.6)
+    for _ in range(5):
+        smoother.add_prediction("A")
+    assert smoother.get_stable_prediction() == "A"
+
+    # Push all A's out by adding 5 B's
+    for _ in range(5):
+        smoother.add_prediction("B")
+    assert smoother.get_stable_prediction() == "B"
+
+
+def test_clear():
+    """Clearing the history should reset to None."""
+    smoother = PredictionSmoother(window_size=5, dominance_threshold=0.6)
+    for _ in range(5):
+        smoother.add_prediction("A")
+    assert smoother.get_stable_prediction() == "A"
+
+    smoother.clear()
+    assert smoother.get_stable_prediction() is None
+
+
+def test_custom_window_size():
+    """Smoother should respect a custom window size."""
+    smoother = PredictionSmoother(window_size=3, dominance_threshold=0.6)
+    for sign in ["X", "X", "Y"]:  # X = 66%
+        smoother.add_prediction(sign)
+    assert smoother.get_stable_prediction() == "X"

--- a/utils/prediction_smoother.py
+++ b/utils/prediction_smoother.py
@@ -1,0 +1,23 @@
+from collections import Counter, deque
+from config import SMOOTHING_WINDOW_SIZE, SMOOTHING_DOMINANCE_THRESHOLD
+
+class PredictionSmoother:
+    def __init__(self, window_size = SMOOTHING_WINDOW_SIZE, dominance_threshold = SMOOTHING_DOMINANCE_THRESHOLD):
+        self.window_size = window_size
+        self.dominance_threshold = dominance_threshold
+        self.prediction_history = deque(maxlen=window_size)
+
+    def add_prediction(self, new_prediction):
+        self.prediction_history.append(new_prediction)
+    
+    def get_stable_prediction(self):
+        if not self.prediction_history:
+            return None
+        prediction, count = Counter(self.prediction_history).most_common(1)[0]
+        ratio = count / len(self.prediction_history)
+        if ratio >= self.dominance_threshold:
+            return prediction
+        return None
+
+    def clear(self):
+        self.prediction_history.clear()


### PR DESCRIPTION
- Add PredictionSmoother using deque and Counter (utils/prediction_smoother.py)
- Add configurable SMOOTHING_WINDOW_SIZE and SMOOTHING_DOMINANCE_THRESHOLD to config
- Integrate smoother into main loop to prevent frame-by-frame flickering
- Clean up imports in main.py (move pickle to top, remove unused xml import)
- Add 8 unit tests covering all smoothing edge cases