### PR TITLE
feat: add text overlay for sign prediction display (issue-17)

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import cv2
 import time
 import pickle
 from core.hand_detector import HandDetector
+from utils.text_overlay import draw_prediction
 from core.feature_extractor import FeatureExtractor
 from utils.prediction_smoother import PredictionSmoother
 from controllers.mouse_controller import MouseController
@@ -19,11 +20,8 @@ controllers = {
     "sign_language": SignLanguageController(),
 }
 
-# Initialize hand detector
-detector = HandDetector(MAX_HANDS, DETECTION_CONFIDENCE, TRACKING_CONFIDENCE)
-
-# hand detection toggle
-current_max_hands = MAX_HANDS
+# Initialize hand detector (start in single hand mode)
+detector = HandDetector(1, DETECTION_CONFIDENCE, TRACKING_CONFIDENCE)
 
 fe=FeatureExtractor(use_z=False)
 
@@ -55,6 +53,7 @@ max_hands_mode = 1 #start with single hand mode
 # Initialize prediction smoother
 smoother = PredictionSmoother(window_size=SMOOTHING_WINDOW_SIZE, dominance_threshold=SMOOTHING_DOMINANCE_THRESHOLD)
 displayed_sign = None
+displayed_confidence = None
 
 # Main loop
 while True:
@@ -78,13 +77,16 @@ while True:
 
         # Predict sign 
         if model is not None:
-            prediction = model.predict(normalized.reshape(1, -1))[0]
+            probabilities = model.predict_proba(normalized.reshape(1, -1))[0]
+            confidence = max(probabilities)
+            prediction = model.classes_[probabilities.argmax()]
             smoother.add_prediction(prediction)
-            stable_prediction = smoother.get_stable_prediction()
+            stable = smoother.get_stable()
 
             # Update displayed sign if stable prediction is available
-            if stable_prediction is not None:
-                displayed_sign = stable_prediction
+            if stable is not None:
+                displayed_sign = stable
+                displayed_confidence = confidence
         
         # Print debug info
         print(f"Features shape: {features.shape}")
@@ -108,28 +110,35 @@ while True:
     cv2.putText(frame, f'Mode: {mode}', (10, 90), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
 
     # Display sign if available
-    if displayed_sign:
-        cv2.putText(frame, f'Sign: {displayed_sign}', (10, 120),
-                    cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+    if displayed_sign and displayed_confidence:
+        draw_prediction(frame, displayed_sign, displayed_confidence)
 
     cv2.imshow(WINDOW_TITLE, frame)
 
     # Handle keypresses
-    """key = cv2.waitKey(1) & 0xFF
+    """
+    key = cv2.waitKey(1) & 0xFF
     if key == ord('m'):
         mode = "sign_language" if mode == "mouse" else "mouse"
     if key == 27 or cv2.getWindowProperty(WINDOW_TITLE, cv2.WND_PROP_VISIBLE) < 1:
-        break"""
+        break
+    """
     
     key = cv2.waitKey(1) & 0xFF
     
     if key == ord('m'):
         mode = "sign_language" if mode == "mouse" else "mouse"
-    if key == ord('h'):
-        #toggle between 1 and 2 hand modes
-        max_hands_mode = 2 if max_hands_mode == 1 else 1
-        detector.hands.max_num_hands = max_hands_mode
-        print(f'Hand dectection mode: {max_hands_mode} hand(s)')
+    """
+    # making the code raedy for future changes regarding translating of 2 hands signing
+    if key == ord('1'):
+        max_hands_mode = 1
+        detector.hands.max_num_hands = 1
+        print('Hand detection mode: 1 hand')
+    if key == ord('2'):
+        max_hands_mode = 2
+        detector.hands.max_num_hands = 2
+        print('Hand detection mode: 2 hands')
+    """
     if key == 27 or cv2.getWindowProperty(WINDOW_TITLE, cv2.WND_PROP_VISIBLE) < 1:
         break
 

--- a/utils/text_overlay.py
+++ b/utils/text_overlay.py
@@ -1,1 +1,59 @@
-# text display on frame
+import cv2
+
+def draw_prediction(frame, label, confidence, position="top-right"):
+    
+    if confidence > 0.8:
+        color = (0, 200, 0)      # green
+    elif confidence >= 0.5:       # implicitly <= 0.8 because of the if above
+        color = (0, 220, 255)     # yellow
+    else:                         # < 0.5
+        color = (0, 0, 220)       # red
+    
+    # h = height in pixels (e.g., 720)
+    # w = width in pixels  (e.g., 1280)
+    # _ = channels (3 for BGR color, we ignore this)
+    h, w, _ = frame.shape
+    padding = 20
+    box_width = 250
+    box_height = 120
+
+    if position == "top-right":
+        x = w - box_width - padding    # e.g., 1280 - 250 - 20 = 1010
+        y = padding                    # 20px from top
+    elif position == "top-left":
+        x = padding                    # 20px from left
+        y = padding                    # 20px from top
+    elif position == "bottom-right":
+        x = w - box_width - padding    # e.g., 1280 - 250 - 20 = 1010
+        y = h - box_height - padding   # e.g., 720 - 120 - 20 = 580
+    elif position == "bottom-left":
+        x = padding                    # 20px from left
+        y = h - box_height - padding   # e.g., 720 - 120 - 20 = 580
+    else:
+        raise ValueError("Invalid position. Must be 'top-right', 'top-left', 'bottom-right', or 'bottom-left'.")
+    
+    # Semi-transparent background rectangle
+    overlay = frame.copy()
+    cv2.rectangle(overlay, (x, y), (x + box_width, y + box_height), (0, 0, 0), cv2.FILLED)
+    cv2.addWeighted(overlay, 0.6, frame, 0.4, 0, frame)
+
+    # Position variables for text and bar
+    text_x = x + 15
+    text_y = y + 40
+    bar_x = x + 15
+    bar_y = y + 70
+    bar_max_width = box_width - 30
+    bar_height = 20
+
+    # Draw label and confidence text
+    cv2.putText(frame, label.upper(), (text_x, text_y), cv2.FONT_HERSHEY_SIMPLEX, 1.5, color, 3)
+    cv2.putText(frame, f"{int(confidence * 100)}%", (text_x, text_y + 40), cv2.FONT_HERSHEY_SIMPLEX, 1.0, color, 2)
+
+    # Gray background bar
+    cv2.rectangle(frame, (bar_x, bar_y), (bar_x + bar_max_width, bar_y + bar_height), (50, 50, 50), cv2.FILLED)
+    
+    # Colored fill bar
+    fill_width = int(bar_max_width * confidence)
+    cv2.rectangle(frame, (bar_x, bar_y), (bar_x + fill_width, bar_y + bar_height), color, cv2.FILLED)
+
+    return frame


### PR DESCRIPTION
- Create utils/text_overlay.py with draw_prediction() function
- Semi-transparent background rectangle for readability
- Color-coded confidence: green (>80%), yellow (50-80%), red (<50%)
- Visual confidence bar and percentage display
- Dynamic positioning based on frame size
- Integrate overlay and predict_proba into main loop
- Fix hand detection startup inconsistency (init with 1 hand)
- Comment out hand mode toggle pending 2-hand support